### PR TITLE
Add session timeout automation utility (terminate_inactive_connections)  

### DIFF
--- a/gp_utils/vacuum/vacuum_full_heap_tables_bloat.py
+++ b/gp_utils/vacuum/vacuum_full_heap_tables_bloat.py
@@ -1,0 +1,125 @@
+#!/usr/bin/python2
+# -*- coding: utf-8 -*-
+"""
+vacuum_full_heap_tables_bloat.py v1.0.0
+Author: Alexander Shcheglov, @sqlmaster (Telegram)
+Purpose: Perform VACUUM FULL on bloated tables in Greenplum database in parallel 6 processes.
+
+Example starting:
+    ./vacuum_tables_parallel.py
+"""
+import os
+import sys
+import logging
+import subprocess
+from datetime import datetime
+from multiprocessing import Pool
+from logging.handlers import WatchedFileHandler
+
+# Настройка логирования
+log_directory = "/home/gpadmin/arenadata_configs/operation_log"
+if not os.path.exists(log_directory):
+    os.makedirs(log_directory)
+
+log_filename = "vacuum_full_tables_{0}.log".format(datetime.now().strftime('%Y%m%d'))
+log_filepath = os.path.join(log_directory, log_filename)
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
+
+stdout_handler = logging.StreamHandler(sys.stdout)
+stdout_handler.setFormatter(formatter)
+logger.addHandler(stdout_handler)
+
+file_handler = WatchedFileHandler(log_filepath, mode='a')
+file_handler.setFormatter(formatter)
+logger.addHandler(file_handler)
+
+DB_CONFIG = {
+    "dbname": "adb",
+    "user": "gpadmin",
+    "host": "127.0.0.1",
+    "port": "5432"
+}
+
+def get_sql_query():
+    return """
+        SELECT
+            bdinspname AS schema_name,
+            bdirelname AS relname
+        FROM
+            gp_toolkit.gp_bloat_diag
+        JOIN pg_catalog.pg_class cl ON
+            bdirelid = cl.oid
+        WHERE
+            CAST(bdirelpages AS NUMERIC(12,0)) * 32 / 1024 > 100
+            AND relpersistence = 'p'
+        ORDER BY
+            bdirelpages DESC;
+    """
+
+def get_table_list():
+    try:
+        sql_query = get_sql_query()
+        psql_cmd = [
+            "psql",
+            "-d", DB_CONFIG["dbname"],
+            "-U", DB_CONFIG["user"],
+            "-h", DB_CONFIG["host"],
+            "-p", DB_CONFIG["port"],
+            "-c", sql_query,
+            "-tA"
+        ]
+        result = subprocess.Popen(psql_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = result.communicate()
+        if result.returncode != 0:
+            raise subprocess.CalledProcessError(result.returncode, psql_cmd, stderr)
+        tables = []
+        for line in stdout.strip().split("\n"):
+            if line:
+                parts = line.split("|")
+                if len(parts) == 2:
+                    tables.append(tuple(parts))
+                else:
+                    logger.warning("Invalid line in output: '{0}'".format(line))
+        logger.info("Found {0} bloated tables requiring VACUUM FULL.".format(len(tables)))
+        return tables
+    except subprocess.CalledProcessError as e:
+        logger.error("psql execution error: {0}, stderr: {1}".format(e, e.stderr))
+        raise
+    except Exception as e:
+        logger.error("Unknown error fetching table list: {0}".format(e))
+        raise
+
+def vacuum_table(table):
+    try:
+        schemaname, tablename = table
+        psql_cmd = [
+            "psql",
+            "-d", DB_CONFIG["dbname"],
+            "-U", DB_CONFIG["user"],
+            "-h", DB_CONFIG["host"],
+            "-p", DB_CONFIG["port"],
+            "-c", "VACUUM FULL {0}.{1};".format(schemaname, tablename)
+        ]
+        result = subprocess.Popen(psql_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = result.communicate()
+        if result.returncode != 0:
+            raise subprocess.CalledProcessError(result.returncode, psql_cmd, stderr)
+        logger.info("Table {0}.{1} successfully vacuumed.".format(schemaname, tablename))
+    except Exception as e:
+        logger.error("Error vacuuming table {0}.{1}: {2}".format(schemaname, tablename, e))
+
+def main():
+    tables = get_table_list()
+    if tables:
+        pool = Pool(6)
+        pool.map(vacuum_table, tables)
+        pool.close()
+        pool.join()
+    logger.info("VACUUM FULL of all bloated tables completed.")
+
+if __name__ == "__main__":
+    main()

--- a/gp_utils/vacuum/vacuum_full_heap_tables_bloat.py
+++ b/gp_utils/vacuum/vacuum_full_heap_tables_bloat.py
@@ -54,8 +54,8 @@ def get_sql_query():
         JOIN pg_catalog.pg_class cl ON
             bdirelid = cl.oid
         WHERE
-            CAST(bdirelpages AS NUMERIC(12,0)) * 32 / 1024 > 100
-            AND relpersistence = 'p'
+            relpersistence = 'p' 
+            -- AND CAST(bdirelpages AS NUMERIC(12,0)) * 32 / 1024 > 100 -- if needed filter tables size MB
         ORDER BY
             bdirelpages DESC;
     """

--- a/session_management/FUNCTION_adm.terminate_inactive_connections.sql
+++ b/session_management/FUNCTION_adm.terminate_inactive_connections.sql
@@ -1,0 +1,48 @@
+CREATE SCHEMA IF NOT EXISTS adm;
+COMMENT ON SCHEMA adm IS 'Schema for administrative functions and utilities';
+CREATE OR REPLACE FUNCTION adm.terminate_inactive_connections (p_login varchar, p_timeout int4)
+    RETURNS SETOF text
+    LANGUAGE sql
+    VOLATILE
+    AS $$
+    -- ver 1.0.3
+    SELECT
+        FORMAT('%s: Session with pid=%s; user=%s; database=%s; application=%s; IP=%s; state=%s; terminated: %s', 
+               current_timestamp(0), pid, usename, datname, application_name, client_addr, state, 
+               pg_terminate_backend(pid, 'session timeout ' || 
+               CASE 
+                   WHEN usename IN (SELECT u.usename 
+                                  FROM pg_user u 
+                                  JOIN pg_group g ON u.usesysid = ANY (g.grolist) 
+                                  WHERE g.groname = 'ldap_users') 
+                   THEN p_timeout::varchar 
+                   ELSE '172800' 
+               END || ' seconds')::varchar)
+    FROM
+        pg_stat_activity
+    WHERE
+        state IN ('idle', 'idle in transaction', 'idle in transaction (aborted)', 'disabled')
+        AND usename LIKE p_login
+        AND CURRENT_TIMESTAMP - state_change > INTERVAL '1 second' * 
+            CASE 
+                WHEN usename IN (SELECT u.usename 
+                               FROM pg_user u 
+                               JOIN pg_group g ON u.usesysid = ANY (g.grolist) 
+                               WHERE g.groname = 'ldap_users') 
+                THEN p_timeout 
+                ELSE 172800 
+            END
+        AND application_name != 'gp_reserved_gpdiskquota'
+        AND usename NOT IN ('gpadmin', 'adcc')
+$$;
+
+COMMENT ON FUNCTION adm.terminate_inactive_connections_2(varchar, int4) IS 
+'Version: 1.0.3
+Terminates idle database sessions based on timeout thresholds. 
+Parameters: p_login (varchar) - username pattern (''%'' for all), p_timeout (int4) - timeout in seconds for ldap_users group (e.g., 1800 = 30 minutes).
+Behavior: Uses p_timeout for ldap_users group, 172800 seconds (48 hours) for others. 
+Excludes gpadmin, adcc, and ''gp_reserved_gpdiskquota'' sessions. 
+Targets idle, idle in transaction, idle in transaction (aborted), and disabled states. 
+Crontab recommendation: not more frequent than */3 * * * * (every 3 minutes) to avoid excessive load.
+Example:
+select adm.terminate_inactive_connections(''%'', 1800)';

--- a/session_management/terminate_inactive_connections.sh
+++ b/session_management/terminate_inactive_connections.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+LOCKFILE=$(dirname $0)/locks/$(basename $0 .sh).lock
+flock -n "$LOCKFILE" /usr/lib/gpdb/bin/psql -U gpadmin -d adb  -c "select gpadmin.terminate_inactive_connections('%', 1800)" | grep Session >> "$MASTER_DATA_DIRECTORY/pg_log/terminate_backend_by_function-$(date +%Y-%m-%d).log" 2>&1

--- a/session_management/terminate_inactive_connections.v1.0.3.md
+++ b/session_management/terminate_inactive_connections.v1.0.3.md
@@ -1,0 +1,73 @@
+# Скрипт для автоматического завершения неактивных соединений в Greenplum --ver 1.0.3
+## Copyright 2025 Alexander Shcheglov
+## 1800 секунд = 30 минут (1800 / 60) -- для пользовательских ролей ldap_users
+## 172800 секунд = 48 часов (172800 / 3600) -- для технических ролей, которые не входят в ldap_users
+
+## строка в crontab
+*/3 * * * *. "$PROFILE" && "$HOME"/adm/scripts/terminate_inactive_connections.sh 
+```sh
+cat ~/adm/scripts/terminate_inactive_connections.sh
+#!/bin/bash
+LOCKFILE=$(dirname $0)/locks/$(basename $0 .sh).lock
+flock -n "$LOCKFILE" /usr/lib/gpdb/bin/psql -U gpadmin -d adb  -c "select gpadmin.terminate_inactive_connections('%', 1800)" | grep Session >> "$MASTER_DATA_DIRECTORY/pg_log/terminate_backend_by_function-$(date +%Y-%m-%d).log" 2>&1
+```
+## для примера как можно поулучить логины которые входят в ldap_users 
+```sql 
+SELECT
+    u.usename,
+    g.groname
+FROM
+    pg_user u
+    JOIN pg_group g ON u.usesysid = ANY (g.grolist)
+WHERE
+    g.groname = 'ldap_users';
+```
+# функция
+```sql
+CREATE OR REPLACE FUNCTION adm.terminate_inactive_connections (p_login varchar, p_timeout int4)
+    RETURNS SETOF text
+    LANGUAGE sql
+    VOLATILE
+    AS $$
+    -- ver 1.0.3
+    SELECT
+        FORMAT('%s: Session with pid=%s; user=%s; database=%s; application=%s; IP=%s; state=%s; terminated: %s', 
+               current_timestamp(0), pid, usename, datname, application_name, client_addr, state, 
+               pg_terminate_backend(pid, 'session timeout ' || 
+               CASE 
+                   WHEN usename IN (SELECT u.usename 
+                                  FROM pg_user u 
+                                  JOIN pg_group g ON u.usesysid = ANY (g.grolist) 
+                                  WHERE g.groname = 'ldap_users') 
+                   THEN p_timeout::varchar 
+                   ELSE '172800' 
+               END || ' seconds')::varchar)
+    FROM
+        pg_stat_activity
+    WHERE
+        state IN ('idle', 'idle in transaction', 'idle in transaction (aborted)', 'disabled')
+        AND usename LIKE p_login
+        AND CURRENT_TIMESTAMP - state_change > INTERVAL '1 second' * 
+            CASE 
+                WHEN usename IN (SELECT u.usename 
+                               FROM pg_user u 
+                               JOIN pg_group g ON u.usesysid = ANY (g.grolist) 
+                               WHERE g.groname = 'ldap_users') 
+                THEN p_timeout 
+                ELSE 172800 
+            END
+        AND application_name != 'gp_reserved_gpdiskquota'
+        AND usename NOT IN ('gpadmin', 'adcc')
+$$ EXECUTE ON ANY;
+
+COMMENT ON FUNCTION adm.terminate_inactive_connections_2(varchar, int4) IS 
+'Version: 1.0.3
+Terminates idle database sessions based on timeout thresholds. 
+Parameters: p_login (varchar) - username pattern (''%'' for all), p_timeout (int4) - timeout in seconds for ldap_users group (e.g., 1800 = 30 minutes).
+Behavior: Uses p_timeout for ldap_users group, 172800 seconds (48 hours) for others. 
+Excludes gpadmin, adcc, and ''gp_reserved_gpdiskquota'' sessions. 
+Targets idle, idle in transaction, idle in transaction (aborted), and disabled states. 
+Crontab recommendation: not more frequent than */3 * * * * (every 3 minutes) to avoid excessive load.
+Example:
+select adm.terminate_inactive_connections('%', 1800);
+```


### PR DESCRIPTION
This PR introduces a utility for automatically terminating inactive database sessions with configurable timeout thresholds.  

### Key features:  
✅ **Smart timeout handling**:  
- 30 minutes (1800s) for `ldap_users` group  
- 48 hours (172800s) for other users  

✅ **Safe exclusions**:  
- Skips system users (`gpadmin`, `adcc`)  
- Ignores `gp_reserved_gpdiskquota` sessions  

✅ **Complete solution includes**:  
1. SQL function `adm.terminate_inactive_connections()`  
2. Bash wrapper script for cron  
3. Documentation with usage examples  

### Usage examples:  
**Manual execution**:  
```sql
SELECT adm.terminate_inactive_connections('%', 1800);
```

**Automated execution (cron)**:  
```bash
*/3 * * * * /path/to/terminate_inactive_connections.sh
```

### Files changed:  
```
useful_scripts/session_management/
├── terminate_inactive_connections.v1.0.3.md  # Full documentation
├── terminate_inactive_connections.sh         # Cron-ready wrapper
└── locks/                                    # Lockfile directory
```

### Why this is useful:  
- Prevents idle sessions from consuming resources  
- Differentiated timeout policies for different user groups  
- Safe for production (excludes critical system processes)  

**Note**: Requires PostgreSQL/Greenplum with `pg_terminate_backend()` privileges.

